### PR TITLE
use simple link

### DIFF
--- a/public/views/help/index.html.erb
+++ b/public/views/help/index.html.erb
@@ -123,9 +123,7 @@ Some finding aids on this website will also contain a hierarchical structure wit
 <div id="questions">
   <h2>What if I have questions? Where should I go for help?</h2>
   <p>If you have questions about a finding aid, please use the <strong>Ask a Question</strong> button in the upper right corner of the finding aid. Please consult the help page to see if your question has already been answered before asking a question.</p>
-  <p>If you have a general question, you are welcome to submit it here:<br/><br/>
-    <a class="btn btn-default page_action" title="Ask a Question" href="mailto: spcarref@uoregon.edu">
-                <img src="assets/images/question.png" alt="Ask a question"/>
-     </a>
+  <p>If you have a general question, you are welcome to submit it to
+    <a href="mailto: spcarref@uoregon.edu">spcarref@uoregon.edu</a>
   </p>
 </div>


### PR DESCRIPTION
Currently, the user is encouraged to contact the ref email but uses a button with an icon that is below a bunch of non-functioning icons. This replaces button with simple email link to avoid user confusion 