### PR TITLE
remove confusing bit

### DIFF
--- a/public/views/help/index.html.erb
+++ b/public/views/help/index.html.erb
@@ -76,7 +76,7 @@
 
 <div id="request">
 	<h2>How do I request materials?</h2>
-  <p>To request materials, please select the “Request” button at the top of the finding aid page and fill out the form.</p>
+  <p>To request materials, please select the “Request” button at the top of the finding aid.</p>
   <img src="assets/images/request.png" alt="Request icon" style="padding-bottom:1em;"/>
   <p> To request materials, please select the “Request” button at the top of the finding aid page which navigates you to the collection’s catalog record in the UO Libraries catalog. You must sign into your account in order to request materials.  For more information, please consult our websites about <a href="https://library.uoregon.edu/special-collections/registration">account registration</a> and  <a href="https://library.uoregon.edu/special-collections/request">requesting materials</a>.
 <p><strong>Materials must be requested at least 5 business days in advance of a research visit. </strong></p>


### PR DESCRIPTION
per Lauren request, remove "and fill out the form" from the request instructions on the help page.